### PR TITLE
python_http_client 3.3.7 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,8 +6,9 @@ package:
   version: '{{ version }}'
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: bf841ee45262747e00dec7ee9971dfb8c7d83083f5713596488d67739170cea0
+  #url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  url: https://github.com/sendgrid/{{ name.replace('_', '-') }}/archive/refs/tags/{{ version }}.tar.gz
+  sha256: 4b87ce2dbebae18e21453ac1b8c7ea31ef3139c94decc85ff5a07d4203671c56
 
 build:
   skip: true  # [py<34 or py>310]
@@ -21,9 +22,34 @@ requirements:
   run:
     - python
 
+  {% set skip_tests = "" %}
+  # Broken test: Compares current machine time with copyright notice's old year
+  {% set skip_tests = skip_tests + " --deselect=tests/test_daterange.py::DateRangeTest::test__daterange" %}
+
 test:
+  source_files:
+    - tests
+    # Required for tests/test_repofiles.py::RepoFiles::test_file_existence
+    - LICENSE
+    - Dockerfile
+    - CHANGELOG.md
+    - CODE_OF_CONDUCT.md
+    - CONTRIBUTING.md
+    - ISSUE_TEMPLATE.md
+    - PULL_REQUEST_TEMPLATE.md
+    - README.rst
+    - TROUBLESHOOTING.md
+    - USAGE.md
+    - VERSION.txt
+    - ./docker-compose.yml
+    - .env_sample
+    - .gitignore
+  requires:
+    - pytest
   imports:
     - python_http_client
+  commands:
+    - pytest -vv {{ skip_tests }} tests
 
 about:
   home: https://github.com/sendgrid/sendgrid-python/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "python_http_client" %}
-{% set version = "3.3.2" %}
+{% set version = "3.3.7" %}
 {% set file_ext = "tar.gz" %}
-{% set hash_value = "67e6a7bea19b03e14dc971480d3531b80becfc203d6c69478561bf7844d52661" %}
+{% set hash_value = "bf841ee45262747e00dec7ee9971dfb8c7d83083f5713596488d67739170cea0" %}
 
 package:
   name: '{{ name|lower }}'

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,6 +45,8 @@ test:
     - .env_sample
     - .gitignore
   requires:
+    - python
+    - pip
     - pytest
   imports:
     - python_http_client
@@ -54,15 +56,14 @@ test:
     - pytest -vv {{ skip_tests }} tests
 
 about:
-  home: https://github.com/sendgrid/sendgrid-python/
+  home: https://github.com/sendgrid/sendgrid-python
   license: MIT
   license_family: MIT
-  # https://github.com/sendgrid/python-http-client/pull/87
-  license_file: '{{ environ["RECIPE_DIR"] }}/LICENSE.txt'
+  license_file: LICENSE
   summary: "SendGrid's Python HTTP Client for calling APIs"
   description: "Quickly and easily access any RESTful or RESTful-like API"
-  doc_url: 'https://github.com/sendgrid/python-http-client'
-  dev_url: 'https://github.com/sendgrid/python-http-client'
+  doc_url: https://github.com/sendgrid/python-http-client
+  dev_url: https://github.com/sendgrid/python-http-client
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,9 +10,9 @@ source:
   sha256: bf841ee45262747e00dec7ee9971dfb8c7d83083f5713596488d67739170cea0
 
 build:
+  skip: true  # [py<34 or py>310]
   number: 0
-  noarch: python
-  script: python -m pip install --no-deps --ignore-installed .
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed -vvv
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,5 @@
 {% set name = "python_http_client" %}
 {% set version = "3.3.7" %}
-{% set file_ext = "tar.gz" %}
-{% set hash_value = "bf841ee45262747e00dec7ee9971dfb8c7d83083f5713596488d67739170cea0" %}
 
 package:
   name: '{{ name|lower }}'
@@ -9,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: '{{ hash_value }}'
+  sha256: bf841ee45262747e00dec7ee9971dfb8c7d83083f5713596488d67739170cea0
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,6 @@ package:
   version: '{{ version }}'
 
 source:
-  #url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   url: https://github.com/sendgrid/{{ name.replace('_', '-') }}/archive/refs/tags/{{ version }}.tar.gz
   sha256: 4b87ce2dbebae18e21453ac1b8c7ea31ef3139c94decc85ff5a07d4203671c56
 
@@ -19,6 +18,7 @@ requirements:
   host:
     - python
     - pip
+    - wheels
   run:
     - python
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,6 +49,8 @@ test:
   imports:
     - python_http_client
   commands:
+    - pip check
+    - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
     - pytest -vv {{ skip_tests }} tests
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ requirements:
   host:
     - python
     - pip
-    - wheels
+    - wheel
   run:
     - python
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 4b87ce2dbebae18e21453ac1b8c7ea31ef3139c94decc85ff5a07d4203671c56
 
 build:
-  skip: true  # [py<34 or py>310]
+  skip: true  # [py<34]
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed -vvv
 
@@ -18,6 +18,7 @@ requirements:
   host:
     - python
     - pip
+    - setuptools
     - wheel
   run:
     - python
@@ -25,25 +26,12 @@ requirements:
   {% set skip_tests = "" %}
   # Broken test: Compares current machine time with copyright notice's old year
   {% set skip_tests = skip_tests + " --deselect=tests/test_daterange.py::DateRangeTest::test__daterange" %}
+  # Test is pointless for packaging, it only checks for presence of repo files (readme, etc).
+  {% set skip_tests = skip_tests + " --deselect=tests/test_repofiles.py::RepoFiles::test_file_existence" %}
 
 test:
   source_files:
     - tests
-    # Required for tests/test_repofiles.py::RepoFiles::test_file_existence
-    - LICENSE
-    - Dockerfile
-    - CHANGELOG.md
-    - CODE_OF_CONDUCT.md
-    - CONTRIBUTING.md
-    - ISSUE_TEMPLATE.md
-    - PULL_REQUEST_TEMPLATE.md
-    - README.rst
-    - TROUBLESHOOTING.md
-    - USAGE.md
-    - VERSION.txt
-    - ./docker-compose.yml
-    - .env_sample
-    - .gitignore
   requires:
     - python
     - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -56,12 +56,12 @@ test:
     - pytest -vv {{ skip_tests }} tests
 
 about:
-  home: https://github.com/sendgrid/sendgrid-python
+  home: https://sendgrid.com
   license: MIT
   license_family: MIT
   license_file: LICENSE
-  summary: "SendGrid's Python HTTP Client for calling APIs"
-  description: "Quickly and easily access any RESTful or RESTful-like API"
+  summary: Twilio SendGrid's Python HTTP Client for calling APIs
+  description: Quickly and easily access any RESTful or RESTful-like API
   doc_url: https://github.com/sendgrid/python-http-client
   dev_url: https://github.com/sendgrid/python-http-client
 


### PR DESCRIPTION
python_http_client 3.3.7 

**Destination channel:** Defaults

### Links

- [PKG-8584]
- dev_url:        https://github.com/sendgrid/python-http-client/tree/3.3.7
- conda_forge:    https://github.com/conda-forge/python_http_client-feedstock
- pypi:           https://pypi.org/project/python_http_client/3.3.7
- pypi inspector: https://inspector.pypi.io/project/python_http_client/3.3.7

### Explanation of changes:

- new version number


[PKG-8584]: https://anaconda.atlassian.net/browse/PKG-8584?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ